### PR TITLE
[Fix #36] `Rake/Desc` should not generate offense for prerequisite declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#33](https://github.com/rubocop/rubocop-rake/pull/33): Drop support for Ruby 2.3. ([@koic][])
 * [#34](https://github.com/rubocop/rubocop-rake/pull/34): Require RuboCop 1.0 or higher. ([@koic][])
 * [#38](https://github.com/rubocop/rubocop-rake/pull/37): Drop support for Ruby 2.4. ([@tejasbubane])
+* [#36](https://github.com/rubocop/rubocop-rake/issues/36): Fix `Rake/Desc` to not generate offense for prerequisite declarations. ([@tejasbubane][])
 
 ## 0.5.1 (2020-02-14)
 

--- a/lib/rubocop/cop/rake/desc.rb
+++ b/lib/rubocop/cop/rake/desc.rb
@@ -33,9 +33,16 @@ module RuboCop
 
         MSG = 'Describe the task with `desc` method.'
 
+        def_node_matcher :prerequisites, <<~PATTERN
+          (send nil? :task (hash (pair _ $_)))
+        PATTERN
+
         def on_task(node)
           return if task_with_desc?(node)
           return if Helper::TaskName.task_name(node) == :default
+
+          requirements = prerequisites(node)
+          return if requirements&.array_type?
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/rake/desc_spec.rb
+++ b/spec/rubocop/cop/rake/desc_spec.rb
@@ -63,4 +63,17 @@ RSpec.describe RuboCop::Cop::Rake::Desc, :config do
       task.name
     RUBY
   end
+
+  it 'registers an offense for one prerequisite declaration (alias)' do
+    expect_offense(<<~RUBY)
+      task release: 'changelog:check_clean'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
+    RUBY
+  end
+
+  it 'does not register an offense for multiple prerequisite declarations' do
+    expect_no_offenses(<<~RUBY)
+      task release: ['changelog:check_clean', 'changelog:create']
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #36