### PR TITLE
Use `RESTRICT_ON_SEND`

### DIFF
--- a/lib/rubocop/cop/rake/helper/on_task.rb
+++ b/lib/rubocop/cop/rake/helper/on_task.rb
@@ -7,6 +7,8 @@ module RuboCop
         module OnTask
           extend NodePattern::Macros
 
+          RESTRICT_ON_SEND = %i[task].freeze
+
           def_node_matcher :task?, <<~PATTERN
             (send nil? :task ...)
           PATTERN


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/8365.

This PR uses `RESTRICT_ON_SEND` to restrict callbacks `on_send` to specific method names only.