### PR TITLE
Set `rubygems_mfa_required` in gemspec

### DIFF
--- a/rubocop-rake.gemspec
+++ b/rubocop-rake.gemspec
@@ -14,11 +14,13 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
   spec.licenses = ['MIT']
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org"
-
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "https://github.com/rubocop/rubocop-rake/blob/master/CHANGELOG.md"
+  spec.metadata = {
+    'allowed_push_host' => 'https://rubygems.org',
+    'homepage_uri' => spec.homepage,
+    'source_code_uri' => spec.homepage,
+    'changelog_uri' => "https://github.com/rubocop/rubocop-rake/blob/master/CHANGELOG.md",
+    'rubygems_mfa_required' => 'true'
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Follows rubocop/rubocop#10239. Update gemspec to require MFA for privileged operations.