### PR TITLE
Add more usage instructions for `rubocop-rake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,42 @@ Or install it yourself as:
 
 ## Usage
 
+You need to tell RuboCop to load the Rake extension. There are three
+ways to do this:
+
+### RuboCop configuration file
+
 Put this into your `.rubocop.yml`.
 
 ```yaml
 require: rubocop-rake
 ```
+
+Alternatively, use the following array notation when specifying multiple extensions.
+
+```yaml
+require:
+  - rubocop-other-extension
+  - rubocop-rake
+```
+
+Now you can run `rubocop` and it will automatically load the RuboCop Rake
+cops together with the standard cops.
+
+### Command line
+
+```bash
+rubocop --require rubocop-rake
+```
+
+### Rake task
+
+```ruby
+RuboCop::RakeTask.new do |task|
+  task.requires << 'rubocop-rake'
+end
+```
+
 
 ## Development
 


### PR DESCRIPTION
This PR brings the usage instructions for `rubocop-rake` up-to-date with the instructions for other `rubocop` extensions, most notably `rubocop-minitest` _(which it now matches)_.