### PR TITLE
Add import path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ rubocop --require rubocop-rake
 ### Rake task
 
 ```ruby
+require 'rubocop/rake_task'
+
 RuboCop::RakeTask.new do |task|
   task.requires << 'rubocop-rake'
 end


### PR DESCRIPTION
Hi all, very small PR to add the `rubocop/rake_task` import path to the example `Rakefile`.

Other whitespace differences are because I formatted the README's Markdown with `deno fmt`.