### PR TITLE
Drop Ruby 2.5 and 2.6 for runtime environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5"
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 InternalAffairs/NodeMatcherDirective:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#57](https://github.com/rubocop/rubocop-rake/pull/57): Drop support Ruby 2.5 and 2.6 for runtime environment. ([@koic][])
+
 ## 0.6.0 (2021-06-29)
 
 ### Changes

--- a/rubocop-rake.gemspec
+++ b/rubocop-rake.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{A RuboCop plugin for Rake}
   spec.description   = %q{A RuboCop plugin for Rake}
   spec.homepage      = "https://github.com/rubocop/rubocop-rake"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
   spec.licenses = ['MIT']
 
   spec.metadata = {


### PR DESCRIPTION
This PR makes RuboCop Rake to require Ruby 2.7+ as its runtime environment. RuboCop has supported Ruby 2.7+ for a long time, so there would be no point in only supporting RuboCop Rake for Ruby 2.6 and older.