### PR TITLE
Fix incorrect plugin version when displaing `rubocop -V`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#59](https://github.com/rubocop/rubocop-rake/pull/59): Fix incorrect plugin version when displaing `rubocop -V`. ([@koic][])
+
 ## 0.7.0 (2025-02-16)
 
 ### New features

--- a/lib/rubocop/rake/plugin.rb
+++ b/lib/rubocop/rake/plugin.rb
@@ -9,7 +9,7 @@ module RuboCop
       def about
         LintRoller::About.new(
           name: 'rubocop-rake',
-          version: Version::STRING,
+          version: VERSION,
           homepage: 'https://github.com/rubocop/rubocop-rake',
           description: 'A RuboCop plugin for Rake.',
         )


### PR DESCRIPTION
This commit fixes incorrect plugin version when displaing `rubocop -V`.

## Before

The RuboCop core version is displayed incorrectly for `rubocop-rake`:

```console
$ bundle exec rubocop -V
1.72.1 (using Parser 3.3.6.0, rubocop-ast 1.38.0, analyzing as Ruby 3.4, running on ruby 3.4.1) [x86_64-darwin23]
  - rubocop-rake 1.72.1
```

## After

The correct `rubocop-rake` version is displayed:

```console
$ bundle exec rubocop -V
1.72.1 (using Parser 3.3.6.0, rubocop-ast 1.38.0, analyzing as Ruby 3.4, running on ruby 3.4.1) [x86_64-darwin23]
  - rubocop-rake 0.7.0
```