### PR TITLE
[Fix #49] Fix false negatives for `Rake/Desc` when a task has a single prerequisite in an array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#49](https://github.com/rubocop/rubocop-rake/issues/49): Fix false negatives for `Rake/Desc` when a task has a single prerequisite in an array. ([@ydakuka][])
+
 ## 0.7.1 (2025-02-16)
 
 ### Bug fixes
@@ -78,3 +80,4 @@
 [@jaruuuu]: https://github.com/jaruuuu
 [@koic]: https://github.com/koic
 [@tejasbubane]: https://github.com/tejasbubane
+[@ydakuka]: https://github.com/ydakuka

--- a/lib/rubocop/cop/rake/desc.rb
+++ b/lib/rubocop/cop/rake/desc.rb
@@ -39,10 +39,8 @@ module RuboCop
 
         def on_task(node)
           return if task_with_desc?(node)
-          return if Helper::TaskName.task_name(node) == :default
-
-          requirements = prerequisites(node)
-          return if requirements&.array_type?
+          return if default_task?(node)
+          return if multiple_prerequisites?(node)
 
           add_offense(node)
         end
@@ -75,6 +73,18 @@ module RuboCop
 
         private def can_insert_desc_to?(parent)
           parent.type?(:begin, :block, :kwbegin)
+        end
+
+        private def default_task?(node)
+          Helper::TaskName.task_name(node) == :default
+        end
+
+        private def multiple_prerequisites?(node)
+          requirements = prerequisites(node)
+          return false unless requirements&.array_type?
+
+          children = requirements.children
+          children && children.size > 1
         end
       end
     end

--- a/spec/rubocop/cop/rake/desc_spec.rb
+++ b/spec/rubocop/cop/rake/desc_spec.rb
@@ -68,12 +68,28 @@ RSpec.describe RuboCop::Cop::Rake::Desc, :config do
     expect_offense(<<~RUBY)
       task release: 'changelog:check_clean'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
+
+      task release: :changelog
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
+
+      task release: %w[changelog]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
+
+      task release: %i[changelog]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
+
+      task "release" => :environment
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Describe the task with `desc` method.
     RUBY
   end
 
   it 'does not register an offense for multiple prerequisite declarations' do
     expect_no_offenses(<<~RUBY)
       task release: ['changelog:check_clean', 'changelog:create']
+
+      task release: %w[changelog lint]
+
+      task release: %i[changelog lint]
     RUBY
   end
 end


### PR DESCRIPTION
Fix #49 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.